### PR TITLE
Update readme.md

### DIFF
--- a/02-html-css-js/reading-deleting-dom-elements/readme.md
+++ b/02-html-css-js/reading-deleting-dom-elements/readme.md
@@ -52,7 +52,7 @@ console.log(heading);
 
 ### querySelectorAll()
 
-To select multiple elements, you should use `document.querySelector()` which will select _all elements_ that match the given selector. This will return a [NodeList](https://developer.mozilla.org/en-US/docs/Web/API/NodeList), which is an array-like structure.
+To select multiple elements, you should use `document.querySelectorAll()` which will select _all elements_ that match the given selector. This will return a [NodeList](https://developer.mozilla.org/en-US/docs/Web/API/NodeList), which is an array-like structure.
 
 ```js
 const paragraphs = document.querySelectorAll("p");


### PR DESCRIPTION
The querySelectorAll() section had a typo, that's all! It mentioned querySelector() instead of querySelectorAll().